### PR TITLE
Align the sidebar identifier with the registered persistent identifier

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -198,7 +198,7 @@
       sections:
         - file: content/recipes/reusability/miappe #FCB061
           title: Improving dataset maturity - MIAPPE-compliant submission to EMBL-EBI databases
-        - file: content/recipes/reusability/plant-pheno-data-publication #FCB083PRE
+        - file: content/recipes/reusability/plant-pheno-data-publication #FCB083
           title: Publishing plant phenotypic data
         - file: content/recipes/maturity/isa-maturity-progression
           title: Moving through maturity levels with ISA


### PR DESCRIPTION
FCB083PRE is not registered in [w3c](https://w3id.org/) creating problems in RDMkit. FCB083 is registered since it is a mature page. 

