### PR TITLE
Fix broken links to authors' github handles

### DIFF
--- a/_ext/authors_fairplus.py
+++ b/_ext/authors_fairplus.py
@@ -84,7 +84,7 @@ class AuthorsFairplus(Directive):
             
 
             if github_handle != "":
-                github_link_start = '<a target="_blank" href="https://github.com/{github_handle}">'
+                github_link_start = f'<a target="_blank" href="https://github.com/{github_handle}">'
                 github_link_end   = '</a>'
                 github_image_block = f'<img class="avatar-style" src="https://avatars.githubusercontent.com/{github_handle}"></img>'
             else:


### PR DESCRIPTION
This PR fixes broken links to recipe authors' GitHub handles.

For example of the broken links, click any author name on this recipe - https://faircookbook.elixir-europe.org/content/recipes/reusability/plant-pheno-data-publication.html#authors .