### PR TITLE
Update iupac-names recipe (PR #664) and fix broken links

### DIFF
--- a/content/recipes/infrastructure/iupac-names.md
+++ b/content/recipes/infrastructure/iupac-names.md
@@ -28,7 +28,7 @@ The main purpose of this recipe is:
 
 The OPSIN library is an open source tool to parse IUPAC names into chemical graphs {footcite}`Lowe2011Chemical`.
 
-OPSIN has [a website](https://opsin.ch.cam.ac.uk/) where IUPAC names are converted into other representations, including an InChIKey.
+OPSIN has [a website](https://www.ebi.ac.uk/opsin/) where IUPAC names are converted into other representations, including an InChIKey.
 
 The latter is done by the official InChI library {footcite}`Goodman2021InChI`.
 
@@ -42,13 +42,13 @@ to access the OPSIN library.
 We would first need to set up Colab for Java, Maven, and [scyjava](https://pypi.org/project/scyjava/), followed
 by the download of the Bacting libraries and creation of Bacting manager objects.
 
-Java 17 and Maven are installed with the following commands, (with a confirmation which Java is available):
+Java 21 and Maven are installed with the following commands, (with a confirmation which Java is available):
 
 ```python
-apt-get install openjdk-17-jre-headless maven -qq > /dev/null
+apt-get install openjdk-21-jre-headless maven -qq > /dev/null
 import os
-os.environ["JAVA_HOME"] = "/usr/lib/jvm/java-17-openjdk-amd64"
-update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
+os.environ["JAVA_HOME"] = "/usr/lib/jvm/java-21-openjdk-amd64"
+update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
 java -version
 ```
 
@@ -62,8 +62,10 @@ We can then continue by installing Bacting and setting up the two Bacting manage
 
 ```python
 from scyjava import config, jimport
-config.endpoints.append('io.github.egonw.bacting:managers-inchi:0.4.1')
-config.endpoints.append('io.github.egonw.bacting:managers-opsin:0.4.1')
+config.set_java_constraints(fetch=True, vendor='zulu', version='21')
+
+config.endpoints.append('io.github.egonw.bacting:managers-inchi:1.0.12')
+config.endpoints.append('io.github.egonw.bacting:managers-opsin:1.0.12')
 
 inchi_cls = jimport("net.bioclipse.managers.InChIManager")
 inchi = inchi_cls(".")
@@ -91,8 +93,8 @@ Because Bacting is written in Java and the libraries being available from
 The above code in Groovy looks like:
 
 ```groovy
-@Grab(group='io.github.egonw.bacting', module='managers-inchi', version='0.4.1')
-@Grab(group='io.github.egonw.bacting', module='managers-opsin', version='0.4.1')
+@Grab(group='io.github.egonw.bacting', module='managers-inchi', version='1.0.12')
+@Grab(group='io.github.egonw.bacting', module='managers-opsin', version='1.0.12')
 
 workspaceRoot = "."
 inchi = new net.bioclipse.managers.InChIManager(workspaceRoot);

--- a/content/recipes/interoperability/identifier-mapping.md
+++ b/content/recipes/interoperability/identifier-mapping.md
@@ -275,7 +275,7 @@ As a minimum, you should aim to link your dataset's persistant data identifiers 
 ```
 ````
 <!-- 
-    > * [Identifier Resolution Services](./findability/id-resolution.html) 
+    > * [Identifier Resolution Services](fcb-infra-idres) 
 -->
 
 

--- a/content/recipes/interoperability/ontology-robot-recipe/MSIO-robot-build-process.ipynb
+++ b/content/recipes/interoperability/ontology-robot-recipe/MSIO-robot-build-process.ipynb
@@ -320,7 +320,7 @@
     "10. Haug K., Cochrane K., Nainala V.C., Williams M., Chang J., Jayaseelan K.N. and O’Donovan C. MetaboLights: a resource evolving in response to the needs of its scientific community. Nucleic Acids Research, gkz1019, [https://doi.org/10.1093/nar/gkz1019](https://doi.org/10.1093/nar/gkz1019)\n",
     "3. IAO: [https://github.com/information-artifact-ontology/IAO/](https://github.com/information-artifact-ontology/IAO/)\n",
     "4. The Ontology for Biomedical Investigations, PLoS One. 2016 Apr 29;11(4):e0154556. eCollection 2016. [https://doi.org/10.1371/journal.pone.0154556](https://doi.org/10.1371/journal.pone.0154556). \n",
-    "5. STATO: [https:stato-ontology.org](https:stato-ontology.org)\n",
+    "5. STATO: [https://stato-ontology.org](https://stato-ontology.org)\n",
     "6. nmrCV: [http://nmrml.org/cv/](http://nmrml.org/cv/)\n",
     "7. CHMO: [https://github.com/rsc-ontologies/rsc-cmo](https://github.com/rsc-ontologies/rsc-cmo)\n",
     "8. UO: [https://github.com/bio-ontology-research-group/unit-ontology](https://github.com/bio-ontology-research-group/unit-ontology)\n",

--- a/content/recipes/introduction/FAIR-and-knowledge-graphs.md
+++ b/content/recipes/introduction/FAIR-and-knowledge-graphs.md
@@ -336,10 +336,10 @@ CYPHER query example on Reactome: Comparison with SQL. From Fabregat et al,2018.
 ```
 ````
 
-* The [PDBe-KB](PDBe-KG https://www.ebi.ac.uk/pdbe/pdbe-kb/graph-download) is another relevant resources in the fields of
+* The [PDBe-KB](https://www.ebi.ac.uk/pdbe/pdbe-kb/graph-download) is another relevant resources in the fields of
 bioinformatics which is available as a Neo4j graph database. PDBe-KB is a community-driven resource managed by the PDBe
 team, collating functional annotations and predictions for structure data in the PDB archive, the content of which is distributed
-under CC-BY-4 license. PDFe-KB can be downloaded [here](PDBe-KG https://www.ebi.ac.uk/pdbe/pdbe-kb/graph-download).
+under CC-BY-4 license. PDBe-KB can be downloaded [here](https://www.ebi.ac.uk/pdbe/pdbe-kb/graph-download).
 
 
 


### PR DESCRIPTION
Merge from [PR #664](https://github.com/FAIRplus/the-fair-cookbook/pull/664) (author: [egonw](https://github.com/egonw))
iupac-names.md :
- OPSIN website URL -> https://www.ebi.ac.uk/opsin/
- Java 17 -> 21 (install, JAVA_HOME, update-alternatives, prose)
- Bacting managers-inchi/opsin 0.4.1 -> 1.0.12
- add config.set_java_constraints(fetch=True, vendor='zulu', version='21')

Additional broken-link fixes:
- FAIR-and-knowledge-graphs.md: fix malformed PDBe-KB link + "PDFe-KB" typo
- identifier-mapping.md: fix id-resolution cross-ref to fcb-infra-idres (kept commented)
- MSIO-robot-build-process.ipynb: fix STATO URL (https: -> https://)